### PR TITLE
Feat: design forgot password page UI

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -2,12 +2,11 @@ import { ForgotPasswordForm } from "@/components/features/forgot-password/forgot
 
 export default function ForgotPasswordPage() {
   return (
-    <main>
-      <section>
-        <h2>Reset your password</h2>
-        <p>
-          Enter the email you used for registration and {"we'll"} send you a one
-          time code to reset your password.
+    <main className="flex min-h-screen text-center flex-col items-center justify-center bg-[#222222]">
+      <section className="w-full max-w-md px-8">
+        <h2 className="text-2xl mb-2" style={{ fontFamily: 'var(--font-source-serif-pro)' }}>Reset your password</h2>
+        <p className="text-gray-40  0 mb-6" style={{ fontFamily: 'var(--font-manrope)' }}>
+          Enter your email address and we'll send you a link to reset your password 
         </p>
         <ForgotPasswordForm />
       </section>

--- a/src/components/features/forgot-password/forgot-password-form.tsx
+++ b/src/components/features/forgot-password/forgot-password-form.tsx
@@ -31,21 +31,32 @@ export const ForgotPasswordForm = () => {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
+      <form method="POST" onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         <FormField
           control={form.control}
           name="email"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Email</FormLabel>
+              <FormLabel className="text-white text-sm leading-none" style={{ fontFamily: "var(--font-manrope)" }}>Email</FormLabel>
               <FormControl>
-                <Input placeholder="Enter Email" {...field} />
+                <div className="relative">
+                    <img
+                      src="/icons/mail-01.png"
+                      alt="mail"
+                      className="absolute left-3 top-1/2 -translate-y-1/2 size-5"
+                    />
+                    <Input
+                      placeholder="Enter email"
+                      className="bg-[#222222] border border-[#444444] rounded-md pl-10 h-12 text-white"
+                      {...field}
+                    />
+                  </div>
               </FormControl>
               <FormMessage />
             </FormItem>
           )}
         />
-        <Button type="submit">Continue</Button>
+        <Button type="submit" className="w-full py-3 h-12 bg-[#FF7A50] hover:bg-[#FF7A50]/90 text-white rounded-md text-sm leading-none focus:outline-none" style={{ fontFamily: "var(--font-source-serif-pro)" }}>Reset Password</Button>
       </form>
     </Form>
   );


### PR DESCRIPTION
## Description
This pull request adds the user interface design for the Reset Password page.
The page allows users to enter their email address to request a password reset link.
It follows the existing authentication page layout for consistent UI/UX.
<img width="670" height="577" alt="Screenshot 2025-10-07 131405" src="https://github.com/user-attachments/assets/683aa468-2ecc-435e-8d61-28c11b51695c" />


## Additional Notes
No backend logic added yet (UI only).
Ready for review and feedback.