### PR TITLE
feat(ui): add reusable Tabs component for section navigation

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+
+export function Tabs({ tabs }: { tabs: string[] }) {
+  const [active, setActive] = useState(tabs[0]);
+
+  return (
+    <div className="flex justify-center">
+      <div className="inline-flex bg-neutral-900 rounded-2xl p-1 shadow-sm">
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActive(tab)}
+            className={`px-6 py-2 rounded-xl text-sm font-medium transition-colors ${
+              active === tab
+                ? "bg-neutral-100 text-black"
+                : "text-neutral-300 hover:text-white"
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### **Description**
This PR introduces a **reusable Tabs UI component** for navigating between sections such as “Nutritional value”, “Recipe”, and “Restaurants”.  
The component is designed to be lightweight, responsive, and consistent with the app’s existing visual theme.

---

### **What’s New**
- Added a new `Tabs` component to `components/ui`
- Implemented active state highlighting for the selected tab
- Styled using Tailwind with a compact, rounded design
- Centered component horizontally
- Adjusted layout to ensure the container width matches the total tab width (snug-fit)

---

### **Files Added / Modified**
components/
└─ ui/
└─ Tabs.tsx # New reusable Tabs component

---

### **Dependencies Used**
No new dependencies added.  
Used existing **React** and **TailwindCSS** utilities.

---

### **✅ Checklist**
- [x] Component centered horizontally  
- [x] Active tab visual highlight working  
- [x] Responsive layout verified  
- [x] No console warnings  
- [x] Reusable for multiple sections  

---

### **Reviewers**
Request review from:  
**@rahmlad-aramide**