### PR TITLE
fix: normalize login identifier to lowercase for case-insensitive auth

### DIFF
--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -9,7 +9,8 @@ export const LoginFormSchema = z
       })
       .max(64, {
         message: "Email or username cannot exceed 64 characters.",
-      }),
+      })
+      .toLowerCase(),
     password: z
       .string()
       .min(1, {


### PR DESCRIPTION
Signup schema already normalized email/username to lowercase, but login schema did not. This caused authentication failures when users entered mixed-case credentials that didn't match the stored lowercase values.